### PR TITLE
feat: show a profile card when only having one result

### DIFF
--- a/src/SSW.SophieBot/SSWSophieBot/dialogs/GetPeopleBasedOnLocationDialog/GetPeopleBasedOnLocationDialog.dialog
+++ b/src/SSW.SophieBot/SSWSophieBot/dialogs/GetPeopleBasedOnLocationDialog/GetPeopleBasedOnLocationDialog.dialog
@@ -89,6 +89,40 @@
               ],
               "actions": [
                 {
+                  "$kind": "Microsoft.SwitchCondition",
+                  "$designer": {
+                    "id": "sKDev7"
+                  },
+                  "condition": "turn.employees.count",
+                  "cases": [
+                    {
+                      "actions": [
+                        {
+                          "$kind": "Microsoft.SendActivity",
+                          "$designer": {
+                            "id": "OesKIP"
+                          },
+                          "activity": "${SendActivity_OesKIP()}"
+                        },
+                        {
+                          "$kind": "Microsoft.SendActivity",
+                          "$designer": {
+                            "id": "j1tmY1"
+                          },
+                          "activity": "${SendActivity_j1tmY1()}"
+                        },
+                        {
+                          "$kind": "Microsoft.EndDialog",
+                          "$designer": {
+                            "id": "gkrVeH"
+                          }
+                        }
+                      ],
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
                   "$kind": "Microsoft.Foreach",
                   "$designer": {
                     "id": "Qq0pTL"

--- a/src/SSW.SophieBot/SSWSophieBot/dialogs/GetPeopleBasedOnLocationDialog/language-generation/en-us/GetPeopleBasedOnLocationDialog.en-us.lg
+++ b/src/SSW.SophieBot/SSWSophieBot/dialogs/GetPeopleBasedOnLocationDialog/language-generation/en-us/GetPeopleBasedOnLocationDialog.en-us.lg
@@ -1,4 +1,5 @@
 [import](common.lg)
+[Profile](profile.en-us.lg)
 
 # SendActivity_fAH1iZ_text()
 - Sorry, I couldn't find anyone in ${dialog.location}.
@@ -59,3 +60,16 @@
 [Activity
     Attachments = ${json(PeopleListCard(dialog.location, turn.employees))}
 ]
+
+# SendActivity_j1tmY1()
+[Activity
+    Attachments = ${json(ProfileCardWithSSWPeopleAPI(turn.employees[0]))}
+]
+
+# SendActivity_OesKIP()
+[Activity
+    Text = ${SendActivity_OesKIP_text()}
+]
+
+# SendActivity_OesKIP_text()
+- There is only **1** people in **${dialog.location}**.


### PR DESCRIPTION
Currently, we have more than 1 person in every office. So made a few logic change to show the 1 person effect.
![image](https://user-images.githubusercontent.com/37203901/130893285-7d208084-0879-4927-b58e-a5f3f48a60de.png)
**Figure: Show card when having 1 result**