### PR TITLE
Add exception handling for the bot

### DIFF
--- a/src/SSW.SophieBot/SSWSophieBot/Adapters/SSWSophieBotAdapter.cs
+++ b/src/SSW.SophieBot/SSWSophieBot/Adapters/SSWSophieBotAdapter.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.TraceExtensions;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace SSWSophieBot.Adapters
+{
+	public class SSWSophieBotAdapter : CloudAdapter
+	{
+		protected IBotTelemetryClient AdapterBotTelemetryClient { get; }
+
+		public SSWSophieBotAdapter(
+			IConfiguration configuration,
+			IHttpClientFactory httpClientFactory,
+			ILogger<SSWSophieBotAdapter> logger,
+			IEnumerable<IMiddleware> middlewares,
+			IBotTelemetryClient botTelemetryClient)
+			: base(configuration, httpClientFactory, logger)
+		{
+			AdapterBotTelemetryClient = botTelemetryClient;
+
+			foreach (IMiddleware middleware in middlewares)
+			{
+				Use(middleware);
+			}
+
+			OnTurnError = OnTurnErrorAsync;
+		}
+
+		protected virtual async Task OnTurnErrorAsync(ITurnContext turnContext, Exception exception)
+		{
+			var properties = new Dictionary<string, string>
+				{{"Bot exception caught in", $"{nameof(SSWSophieBotAdapter)} - {nameof(OnTurnError)}"}};
+
+			AdapterBotTelemetryClient.TrackException(exception, properties);
+
+			// Log any leaked exception from the application.
+			// NOTE: In production environment, you should consider logging this to
+			// Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+			// to add telemetry capture to your bot.
+			//Logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
+
+			var errorMessageText = "The bot encountered an error or bug.";
+			var errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.IgnoringInput);
+			await turnContext.SendActivityAsync(errorMessage);
+
+			errorMessageText = exception.Message;
+			errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.IgnoringInput);
+			await turnContext.SendActivityAsync(errorMessage);
+
+			var conversationState = turnContext.TurnState.Get<ConversationState>();
+			if (conversationState != null)
+			{
+				try
+				{
+					await conversationState.DeleteAsync(turnContext);
+				}
+				catch (Exception e)
+				{
+					Logger.LogError(e, $"Exception caught on attempting to Delete ConversationState : {e.Message}");
+				}
+			}
+
+			await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+		}
+	}
+}

--- a/src/SSW.SophieBot/SSWSophieBot/Integration/SSWSophieBotTelemetryInitializer.cs
+++ b/src/SSW.SophieBot/SSWSophieBot/Integration/SSWSophieBotTelemetryInitializer.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.Configuration;
+using SSWSophieBot.settings;
+
+namespace SSWSophieBot.Integration
+{
+	public class SSWSophieBotTelemetryInitializer : ITelemetryInitializer
+	{
+		private readonly IConfiguration _configuration;
+
+		public SSWSophieBotTelemetryInitializer(IConfiguration configuration)
+		{
+			_configuration = configuration;
+		}
+
+		public void Initialize(ITelemetry telemetry)
+		{
+			if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+			{
+				var applicationSettings = _configuration.GetSection(ConfigurationConstants.AppSettingsKey).Get<ApplicationSettings>() ?? new ApplicationSettings();
+
+				if (!string.IsNullOrEmpty(applicationSettings.CloudRoleName))
+				{
+					telemetry.Context.Cloud.RoleName = applicationSettings.CloudRoleName;
+				}
+
+				if (!string.IsNullOrEmpty(applicationSettings.CloudRoleInstance))
+				{
+					telemetry.Context.Cloud.RoleInstance = applicationSettings.CloudRoleInstance;
+				}
+			}
+		}
+	}
+}

--- a/src/SSW.SophieBot/SSWSophieBot/Startup.cs
+++ b/src/SSW.SophieBot/SSWSophieBot/Startup.cs
@@ -1,12 +1,18 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using SSWSophieBot.Adapters;
 using SSWSophieBot.HttpClientComponents.Abstractions;
 using SSWSophieBot.HttpClientComponents.PersonQuery;
+using SSWSophieBot.Integration;
 
 namespace SSWSophieBot
 {
@@ -24,6 +30,12 @@ namespace SSWSophieBot
 		{
 			services.AddControllers().AddNewtonsoftJson();
 			services.AddBotRuntime(Configuration);
+
+			services.AddSingleton<SSWSophieBotAdapter>();
+			services.Replace(ServiceDescriptor.Singleton<IBotFrameworkHttpAdapter>(sp => sp.GetRequiredService<SSWSophieBotAdapter>()));
+			services.Replace(ServiceDescriptor.Singleton<BotAdapter>(sp => sp.GetRequiredService<SSWSophieBotAdapter>()));
+
+			services.AddSingleton<ITelemetryInitializer, SSWSophieBotTelemetryInitializer>();
 
 			services.ConfigureSophieBotHttpClient()
 				.AddPersonQueryClient();

--- a/src/SSW.SophieBot/SSWSophieBot/settings/ApplicationSettings.cs
+++ b/src/SSW.SophieBot/SSWSophieBot/settings/ApplicationSettings.cs
@@ -1,0 +1,9 @@
+﻿namespace SSWSophieBot.settings
+{
+	public class ApplicationSettings
+	{
+		public string CloudRoleName { get; set; }
+
+		public string CloudRoleInstance { get; set; }
+	}
+}

--- a/src/SSW.SophieBot/SSWSophieBot/settings/ConfigurationConstants.cs
+++ b/src/SSW.SophieBot/SSWSophieBot/settings/ConfigurationConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace SSWSophieBot.settings
+{
+	public static class ConfigurationConstants
+	{
+		public const string AppSettingsKey = "App";
+	}
+}

--- a/src/SSW.SophieBot/SSWSophieBot/settings/appsettings.example.json
+++ b/src/SSW.SophieBot/SSWSophieBot/settings/appsettings.example.json
@@ -44,7 +44,14 @@
 		"path": "../"
 	},
 	"runtimeSettings": {
-		"adapters": [],
+		"adapters": [
+			{
+				"name": "SSWSophieBotAdapter",
+				"type": "SSWSophieBot.Adapters.SSWSophieBotAdapter",
+				"route": "messages",
+				"enabled": true
+			}
+		],
 		"features": {
 			"removeRecipientMentions": false,
 			"showTyping": false,
@@ -55,7 +62,14 @@
 				"fallbackToTextForSpeechIfEmpty": true
 			}
 		},
-		"components": [],
+		"components": [
+			{
+				"name": "SSWSophieBot.Components"
+			},
+			{
+				"name": "SSWSophieBot.HttpClientComponents.PersonQuery"
+			}
+		],
 		"skills": {
 			"allowedCallers": []
 		},
@@ -69,5 +83,13 @@
 		}
 	},
 	"skillConfiguration": {},
-	"skillHostEndpoint": "http://localhost:3980/api/skills"
+	"skillHostEndpoint": "http://localhost:3980/api/skills",
+	"HttpClient": {
+		"BaseAddress": "",
+		"Endpoints": []
+	},
+	"App": {
+		"CloudRoleName": "SSWSophieBot",
+		"CloudRoleInstance": ""
+	}
 }


### PR DESCRIPTION
Related to #45 

![ErrorResponse](https://user-images.githubusercontent.com/16027480/131466488-1db110ae-1b15-4d8a-80be-436a44ee1887.png)
**Figure: Response for an exception**

![AppInsightsLog](https://user-images.githubusercontent.com/16027480/131466573-fae8fda5-29c8-46f0-be7f-b4c855ddd8bd.png)
**Figure: Application Insights Log for an exception, with specified cloud role name and cloud role instance**

![QueryStatistic](https://user-images.githubusercontent.com/16027480/131466664-89ef7133-cc7e-4052-b390-b98863765583.png)
**Figure: Example statistic for LUIS intent trends on Application Insights**