### PR TITLE
Fix adaptive card display issue on Teams

### DIFF
--- a/src/SSW.SophieBot/SSWSophieBot/dialogs/GetEmployeesByProjectDialog/GetEmployeesByProjectDialog.dialog
+++ b/src/SSW.SophieBot/SSWSophieBot/dialogs/GetEmployeesByProjectDialog/GetEmployeesByProjectDialog.dialog
@@ -81,15 +81,6 @@
                   "workingEmployeesProperty": "turn.workingEmployees"
                 },
                 {
-                  "$kind": "Microsoft.LogAction",
-                  "$designer": {
-                    "id": "TErLJT"
-                  },
-                  "text": "${LogAction_Text_TErLJT()}",
-                  "label": "turn.workingEmployees",
-                  "traceActivity": true
-                },
-                {
                   "$kind": "Microsoft.SendActivity",
                   "$designer": {
                     "id": "xNmCGW"

--- a/src/SSW.SophieBot/SSWSophieBot/dialogs/GetEmployeesByProjectDialog/language-generation/en-us/GetEmployeesByProjectDialog.en-us.lg
+++ b/src/SSW.SophieBot/SSWSophieBot/dialogs/GetEmployeesByProjectDialog/language-generation/en-us/GetEmployeesByProjectDialog.en-us.lg
@@ -19,11 +19,3 @@
 [Activity
     Attachments = ${json(WorkingEmployeesList(turn.workingEmployees))}
 ]
-
-# LogAction_Text_TErLJT()
-[Activity
-    Text = ${LogAction_Text_TErLJT_text()}
-]
-
-# LogAction_Text_TErLJT_text()
-- ${turn.workingEmployees}

--- a/src/SSW.SophieBot/SSWSophieBot/dialogs/GetExpertsByLocationDialog/language-generation/en-us/GetExpertsByLocationDialog.en-us.lg
+++ b/src/SSW.SophieBot/SSWSophieBot/dialogs/GetExpertsByLocationDialog/language-generation/en-us/GetExpertsByLocationDialog.en-us.lg
@@ -67,7 +67,7 @@
             ]
         }
     ],
-    "style": "accent"
+    "style": "default"
 },
 {
     "type": "Container",

--- a/src/SSW.SophieBot/SSWSophieBot/language-generation/en-us/workingList.en-us.lg
+++ b/src/SSW.SophieBot/SSWSophieBot/language-generation/en-us/workingList.en-us.lg
@@ -14,7 +14,8 @@
             "columns": [
                 {
                     "type": "Column",
-                    "width": "50px"
+                    "width": "50px",
+					"items": []
                 },
                 {
                     "type": "Column",
@@ -56,7 +57,7 @@
                 }
             ],
             "bleed": true,
-            "style": "accent",
+            "style": "default",
             "height": "stretch",
             "spacing": "Medium"
         },
@@ -98,9 +99,6 @@
                     "size": "Small"
                 }
             ],
-            "backgroundImage": {
-                "verticalAlignment": "Center"
-            },
             "verticalContentAlignment": "Center"
         },
         {
@@ -127,9 +125,6 @@
                     "size": "Small"
                 }
             ],
-            "backgroundImage": {
-                "verticalAlignment": "Center"
-            },
             "verticalContentAlignment": "Center"
         }
     ],

--- a/src/SSW.SophieBot/SSWSophieBot/language-understanding/en-us/SSWSophieBot.en-us.lu
+++ b/src/SSW.SophieBot/SSWSophieBot/language-understanding/en-us/SSWSophieBot.en-us.lu
@@ -584,8 +584,8 @@
 
 # GetEmployeesOnProject
 - Who is working on {project = SugarLearning}
-- Who is on {project = SophieBot}
-- Show me the people working on {project = SophieHub}
+- Who is on {project = Sophie Bot}
+- Show me the people working on {project = Sophie Hub}
 - Show me who are working on {project = NorthWind}
 
 @ ml project

--- a/src/SSW.SophieBot/components/SSWSophieBot.HttpClientComponents.PersonQuery/Actions/GetEmployeesByProjectAction.cs
+++ b/src/SSW.SophieBot/components/SSWSophieBot.HttpClientComponents.PersonQuery/Actions/GetEmployeesByProjectAction.cs
@@ -8,6 +8,7 @@ using SSWSophieBot.HttpClientComponents.PersonQuery.Models;
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,12 +38,25 @@ namespace SSWSophieBot.HttpClientComponents.PersonQuery.Actions
         {
             static bool IsProjectNameEqual(string sourceProjectName, string originalProjectName)
             {
-                return originalProjectName.Contains(sourceProjectName, StringComparison.OrdinalIgnoreCase);
+                if (string.IsNullOrWhiteSpace(originalProjectName) || string.IsNullOrWhiteSpace(sourceProjectName))
+                {
+                    return false;
+                }
+
+                var _rgx = new Regex("[^a-zA-Z0-9]", RegexOptions.Compiled);
+                var prjName = _rgx.Replace(sourceProjectName, string.Empty);
+                return _rgx.Replace(originalProjectName, string.Empty).IndexOf(prjName, StringComparison.OrdinalIgnoreCase) >= 0;
             }
 
             var queriedProject = dc.GetValue(Project);
+
+            if (string.IsNullOrWhiteSpace(queriedProject))
+            {
+                throw new ArgumentNullException(nameof(Project));
+            }
+
             var employees = dc.GetValue(Employees);
-            var project = employees.FirstOrDefault()?.Projects?.FirstOrDefault(p => IsProjectNameEqual(queriedProject, p.ProjectName))?.ProjectName;
+            var project = employees?.FirstOrDefault()?.Projects?.FirstOrDefault(p => IsProjectNameEqual(queriedProject, p.ProjectName))?.ProjectName;
 
             int BilledDays(GetEmployeeModel model)
             {


### PR DESCRIPTION
1. Fix the list card format error on Teams
2. Refine list card style on Teams (dark mode)
3. Refine GetEmployeesByProject intent
4. Enhance the logic of transforming employees array in GetEmployeesByProjectAction