### PR TITLE
Refine response message for available experts by location

### DIFF
--- a/src/SSW.SophieBot/SSWSophieBot/dialogs/GetAvailableExpertsByLocationDialog/language-generation/en-us/GetAvailableExpertsByLocationDialog.en-us.lg
+++ b/src/SSW.SophieBot/SSWSophieBot/dialogs/GetAvailableExpertsByLocationDialog/language-generation/en-us/GetAvailableExpertsByLocationDialog.en-us.lg
@@ -20,4 +20,6 @@
 ]
 
 # SendActivity_U8Xbbw_text()
-- ${dialog.firstNames} ${if(count(turn.firstNames) > 1, "are", "is")} not on client work with **${dialog.skillEntity}** skills ${if(exists(dialog.locationEntity) && length(dialog.locationEntity) > 0, concat("in", " **", dialog.locationEntity, "**"), "")} on ${turn.formatDate}
+- ```> 🛠${dialog.skillEntity} ${if(exists(dialog.locationEntity) && length(dialog.locationEntity) > 0, concat("| 📍", dialog.locationEntity), "")} | 📅${turn.formatDate}  <br/>
+
+We have ${dialog.firstNames}```


### PR DESCRIPTION
Related to #20 

![image](https://user-images.githubusercontent.com/16027480/133408450-e43b2d00-19c6-4720-b849-1fd1d4dafb26.png)
**Figure: Refined response message for getting available experts in location**