### PR TITLE
Data correction for GetCurrentEmployeesOnLocation dialog

### DIFF
--- a/src/SSW.SophieBot/SSWSophieBot/dialogs/GetCurrentEmployeesOnLocationDialog/GetCurrentEmployeesOnLocationDialog.dialog
+++ b/src/SSW.SophieBot/SSWSophieBot/dialogs/GetCurrentEmployeesOnLocationDialog/GetCurrentEmployeesOnLocationDialog.dialog
@@ -162,6 +162,14 @@
                         {
                           "property": "turn.employees[0].lastSeenInfo",
                           "value": "='Last seen in ${turn.employees[0].lastSeenAt.siteId}.'"
+                        },
+                        {
+                          "value": "=join(select(where(turn.employees[0].skills, s, s.experienceLevel == \"Advanced\"), s, s.technology), \" | \")",
+                          "property": "turn.advancedSkills"
+                        },
+                        {
+                          "property": "turn.intermediateSkills",
+                          "value": "=join(select(where(turn.employees[0].skills, s, s.experienceLevel == \"Intermediate\"), s, s.technology), \" | \")"
                         }
                       ]
                     },


### PR DESCRIPTION
Related to #23 

![image](https://user-images.githubusercontent.com/16027480/139611910-905b451b-b8d5-4bd4-a878-9dfabdf2748d.png)
**Figure: Corrected data**