### PR TITLE
Fix timezone issue when calculating free days

### DIFF
--- a/src/SSW.SophieBot/components/SSWSophieBot.HttpClientComponents.PersonQuery/EmployeesHelper.cs
+++ b/src/SSW.SophieBot/components/SSWSophieBot.HttpClientComponents.PersonQuery/EmployeesHelper.cs
@@ -149,12 +149,12 @@ namespace SSWSophieBot.HttpClientComponents.PersonQuery
                 {
                     unfreeAppointments.Add(a);
 
-                    if (a.End.Date >= lastDate)
+                    if (a.End.UtcDateTime >= lastDate)
                     {
-                        var unfreeDays = (int)Math.Ceiling((a.End.Date.AddDays(1) - (a.Start.Date < lastDate ? lastDate : a.Start.Date)).TotalDays);
+                        var unfreeDays = (int)Math.Ceiling((a.End.UtcDateTime - (a.Start.UtcDateTime < lastDate ? lastDate : a.Start.UtcDateTime)).TotalHours / 24);
 
                         freeDays -= unfreeDays;
-                        lastDate = a.End.Date.AddDays(1);
+                        lastDate = a.End.UtcDateTime;
                     }
                 }
             }


### PR DESCRIPTION
Closes #20 

![image](https://user-images.githubusercontent.com/16027480/141094152-27351f46-79ff-4fc8-bfc7-6a3d3c07bb94.png)
![image](https://user-images.githubusercontent.com/16027480/141094173-388b46d3-4981-450e-a939-2e6e51ede4e8.png)
**Figure: Free days now matches Power BI (tested with local timezone set to UTC)**