### PR TITLE
Update View Projects button text

### DIFF
--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetEmployeeProjects/language-generation/en-us/GetEmployeeProjects.en-us.lg
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetEmployeeProjects/language-generation/en-us/GetEmployeeProjects.en-us.lg
@@ -34,8 +34,37 @@
 
 # SendActivity_W7ne5z()
 [Activity
-    Attachments = ${json(ProjectListCard(turn.billableEmployees.employees[0]))}
+    Attachments = ${json(ViewProjects(turn.billableEmployees.employees[0]))}
 ]
+
+# ViewProjects(profile)
+- IF: ${count(profile.billedProjects) > 0}
+    - ```
+    ${ProjectListCard(profile)}
+    ```
+- ELSE:
+    - ```
+    ${NoProjects()}
+    ```
+
+# NoProjects()
+- ```
+{
+    "type": "AdaptiveCard",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "No projects available",
+            "wrap": true,
+            "horizontalAlignment": "Center",
+            "weight": "Lighter",
+            "isSubtle": true
+        }
+    ],
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.2"
+}
+```
 
 # ProjectListCard(profile)
 - ```
@@ -45,7 +74,20 @@
         {
             "type": "ColumnSet",
             "columns": [ 
-                ${ClickableName(profile.firstName + "'s projects" , profile.firstName, profile.lastName, 'auto', 'large', 'None', 'GetEmployeeProjects')},
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "${profile.displayName}'s projects [${if(count(profile.billedProjects) == 0, "none", count(profile.billedProjects))}]",
+                            "wrap": true,
+                            "size": "Medium",
+                            "weight": "Bolder"
+                        }
+                    ],
+                    "verticalContentAlignment": "Center"
+                }
             ]
         },
         {

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetProfileDialog/GetProfileDialog.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetProfileDialog/GetProfileDialog.dialog
@@ -106,6 +106,14 @@
               ],
               "actions": [
                 {
+                  "$kind": "GetEmployeesByBillableAction",
+                  "$designer": {
+                    "id": "ph1Un5"
+                  },
+                  "employees": "=turn.employees",
+                  "workingEmployeesProperty": "turn.billableEmployees"
+                },
+                {
                   "$kind": "Microsoft.IfCondition",
                   "$designer": {
                     "id": "sm9K8b"

--- a/bots/employee-finder/src/SSW.SophieBot/language-generation/en-us/common.en-us.lg
+++ b/bots/employee-finder/src/SSW.SophieBot/language-generation/en-us/common.en-us.lg
@@ -607,11 +607,11 @@ ${IntranetInfo()}
     }
 	```
 
-# ViewEmployeeProjectsAction(displayName, sourceIntent)
+# ViewEmployeeProjectsAction(displayName, projects, sourceIntent)
 - ```
 {
     "type": "Action.Submit",
-    "title": "View Projects",
+    "title": "View Projects (${if(count(projects.billedProjects) == 0, "none", count(projects.billedProjects))})",
     "iconUrl": "${Dynamics365Icon()}",
     "data": 
     {

--- a/bots/employee-finder/src/SSW.SophieBot/language-generation/en-us/profile.en-us.lg
+++ b/bots/employee-finder/src/SSW.SophieBot/language-generation/en-us/profile.en-us.lg
@@ -358,7 +358,7 @@
             "actions": [
                 ${join(where([
                     ChatInTeamsAction(profile.emailAddress),
-                    ViewEmployeeProjectsAction(turn.displayName, 'GetProfile'),
+                    ViewEmployeeProjectsAction(turn.displayName, turn.billableEmployees.employees[0], 'GetProfile'),
                     ViewBookingsAction(turn.displayName, turn.employees[0].bookedDays, 'GetProfile'),
                     ViewInPeopleAction(profile), 
                     ViewInCRMAction(profile),


### PR DESCRIPTION
<!-- Include the issue it closes -->
closes #470 

<!-- Summarize your changes -->
Updated the View Projects button text with the number of projects. If the user has zero projects, it will show the "View Projects (none)" text in the button so it will not surprise users if they click on the view projects. I have also updated the card if the user has zero projects. 

<!-- include screenshots if relevant -->
<img width="565" alt="Screen Shot 2022-03-07 at 2 00 28 pm" src="https://user-images.githubusercontent.com/80997507/157141253-18976c10-dd36-4b73-b73c-7b4642d73429.png">
Figure: Updated "View Projects" button text (When the user has 3 Projects) and Updated View Projects card title.


<img width="572" alt="Screen Shot 2022-03-07 at 2 00 06 pm" src="https://user-images.githubusercontent.com/80997507/157141306-f2f51a2e-3cea-40fd-8444-653b952c0ad5.png">
Figure: Updated "View Projects" button text (When the user has Zero projects) and Updated View Projects card.
