### PR TITLE
Make work hours field conistent with CRM

### DIFF
--- a/bots/employee-finder/src/SSW.SophieBot/language-generation/en-us/profile.en-us.lg
+++ b/bots/employee-finder/src/SSW.SophieBot/language-generation/en-us/profile.en-us.lg
@@ -162,7 +162,7 @@
 					{
 						"type": "TextBlock",
 						"wrap": true,
-						"text": "${replace(profile.workHours, '\n', ' | ')}"
+						"text": "${replace(profile.workHours, '\n', '\n\n')}"
 					}
 				],
 				"spacing": "None"


### PR DESCRIPTION
<!-- Include the issue it closes -->
Related to #621 

<!-- Summarize your changes -->
- Make the "Work Hours" field consistent with CRM (Keep the same line breaks, previously I was using "|" to make the content more compact)

FYI: As per conversation with @adamcogan, we will make this field fully expanded instead of adding "More" & "Less" buttons.

<!-- include screenshots if relevant -->
<img width="774" alt="image" src="https://github.com/SSWConsulting/SSW.SophieBot/assets/37203901/755e30bc-1149-4b36-a051-56ff679a8dff">

**Figure: Keep the same line breaks**
