### PR TITLE
XS✔ ◾ Bug fixes and enhancement

### DIFF
--- a/bots/employee-finder/src/SSW.SophieBot/Properties/launchSettings.json
+++ b/bots/employee-finder/src/SSW.SophieBot/Properties/launchSettings.json
@@ -18,7 +18,7 @@
     "BotProject": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:3978",
+      "applicationUrl": "http://localhost:3980",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetCurrentEmployeesOnLocationDialog/language-generation/en-us/GetCurrentEmployeesOnLocationDialog.en-us.lg
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetCurrentEmployeesOnLocationDialog/language-generation/en-us/GetCurrentEmployeesOnLocationDialog.en-us.lg
@@ -42,15 +42,16 @@
 - [Debug] - dialog.locationEntity = ${dialog.locationEntity}
 
 # SendActivity_xUKqy3_text()
-- I couldn't find anyone in the **${dialog.locationEntity}** office at this time.
+- I couldn't find anyone in the **${dialog.locationEntity}** office.
 # SendActivity_xUKqy3()
 [Activity
     Text = ${SendActivity_xUKqy3_text()}
 ]
 
 # SendActivity_1H6iXy_text()
-- I couldn't find anyone in any of the offices at this time.
+- I couldn't find anyone in any of the offices.
 # SendActivity_1H6iXy()
 [Activity
     Text = ${SendActivity_1H6iXy_text()}
 ]
+

--- a/bots/employee-finder/src/SSW.SophieBot/language-generation/en-us/profile.en-us.lg
+++ b/bots/employee-finder/src/SSW.SophieBot/language-generation/en-us/profile.en-us.lg
@@ -530,7 +530,7 @@
 - IF: ${ device != null }
     - ```(Device: ${device})```
 - ELSE:
-    -
+    - ```(Device: [Unknown](https://github.com/SSWConsulting/SSW.SophieBot/wiki/Frequently-Asked-Questions#1-why-my-device-name-in-the-profile-card-is-unknown))```
 
 # SkillsInfo()
 - IF: ${length(turn.intermediateSkills) == 0 && length(turn.advancedSkills) == 0}

--- a/bots/employee-finder/src/SSW.SophieBot/language-understanding/en-us/SSWSophieBot.en-us.lu
+++ b/bots/employee-finder/src/SSW.SophieBot/language-understanding/en-us/SSWSophieBot.en-us.lu
@@ -316,6 +316,7 @@
 
 # GetPeopleBasedOnLocation
 - who work[s] in [the] ({@geographyV2}|{@site}) [office][?]^
+- who is in the ({@geographyV2}|{@site}) office?
 - who works in the China office?
 - who works in China office?
 - who works in China?


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

- #664 
- #691

> 2. What was changed?

- Fixed queries
  - who is in the {{ CITY }} office
  
<img width="1007" alt="image" src="https://github.com/SSWConsulting/SSW.SophieBot/assets/37203901/af3c6afd-9f29-4321-a7c6-290bb41f68f5">

  - who is in the {{ CITY }} office {{ DATE RANGE }}

<img width="987" alt="image" src="https://github.com/SSWConsulting/SSW.SophieBot/assets/37203901/78e1275d-07dd-4881-b841-8b6b2c829283">

- Enhanced profile card
  - Show "Unknown" when the device name is empty
  - Add doc - https://github.com/SSWConsulting/SSW.SophieBot/wiki/Frequently-Asked-Questions#1-why-my-device-name-in-the-profile-card-is-unknown

<img width="995" alt="image" src="https://github.com/SSWConsulting/SSW.SophieBot/assets/37203901/9dc01a4f-c9d4-4b33-8603-aceaa646f3ac">

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->