### PR TITLE
XS⚠️ ◾ Exclude internal hours from billed days

### DIFF
--- a/bots/employee-finder/src/SSW.SophieBot.HttpClientComponents.PersonQuery/Actions/GetFreeEmployeesAction.cs
+++ b/bots/employee-finder/src/SSW.SophieBot.HttpClientComponents.PersonQuery/Actions/GetFreeEmployeesAction.cs
@@ -51,7 +51,7 @@ namespace SSW.SophieBot.HttpClientComponents.PersonQuery.Actions
             {
                 employee.NormalizeAppointments(dc);
                 var nextUnavailability = EmployeesHelper.GetNextUnavailability(employee, date, out var freeDays);
-                int billableDays = EmployeesHelper.GetTotalBilledDays(employee.Projects, out var billableHours);
+                int billableDays = EmployeesHelper.GetBilledDays(employee, employee.Projects.FirstOrDefault(), out var billableHours);
                 return new FreeEmployeeModel
                 {
                     FirstName = employee.FirstName,

--- a/bots/employee-finder/src/SSW.SophieBot.HttpClientComponents.PersonQuery/EmployeesHelper.cs
+++ b/bots/employee-finder/src/SSW.SophieBot.HttpClientComponents.PersonQuery/EmployeesHelper.cs
@@ -52,7 +52,7 @@ namespace SSW.SophieBot.HttpClientComponents.PersonQuery
                     foreach (var employeeProject in employeeProjects)
                     {
                         double billableHours = employeeProject.BillableHours;
-                        int billedDays = GetBilledDays(billableHours);
+                        int billedDays = GetBilledDays(e, employeeProject, out billableHours);
                         billedProjects.Add(new BilledProject
                         {
                             BilledDays = billedDays,
@@ -174,28 +174,44 @@ namespace SSW.SophieBot.HttpClientComponents.PersonQuery
             return BookingStatus.Unknown;
         }
 
-        public static int GetBilledDays(double billableHours)
+        // public static int GetBilledDays(double billableHours)
+        // {
+        //     const int HOURS_PER_DAY = 8;
+        //
+        //     return (int)Math.Ceiling(billableHours / HOURS_PER_DAY);
+        // }
+        //
+        // public static int GetTotalBilledDays(List<GetEmployeeProjectModel> Projects, out double billableHours)
+        // {
+        //     billableHours = 0;
+        //
+        //     if (Projects == null || !Projects.Any())
+        //     {
+        //         return 0;
+        //     }
+        //
+        //     foreach (var project in Projects)
+        //     {
+        //         billableHours += project.BillableHours;
+        //     }
+        //
+        //     return GetBilledDays(billableHours);
+        // }
+        
+        public static int GetBilledDays(GetEmployeeModel employee, GetEmployeeProjectModel project, out double billableHours)
         {
-            const int HOURS_PER_DAY = 8;
 
-            return (int)Math.Ceiling(billableHours / HOURS_PER_DAY);
-        }
 
-        public static int GetTotalBilledDays(List<GetEmployeeProjectModel> Projects, out double billableHours)
-        {
-            billableHours = 0;
-
-            if (Projects == null || !Projects.Any())
+            if (project != null && project.CustomerName != "SSW")
             {
-                return 0;
+                billableHours = project?.BillableHours ?? 0;
             }
-
-            foreach (var project in Projects)
-            {
-                billableHours += project.BillableHours;
+            else {
+                billableHours = 0;
             }
+         
 
-            return GetBilledDays(billableHours);
+            return billableHours == 0 ? 0 : (int)Math.Ceiling(billableHours / 8);
         }
 
         public static int GetBookedDays(GetEmployeeModel employee, DateTime startDate)


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

As per my conversation with @jimmidier, billed days should not include internal hours because we only care about client hours.

> 2. What was changed?

This pull request updates the employee billing logic to improve accuracy when calculating billed days, especially regarding project-specific billing and excluding internal projects. The changes primarily refactor how billed days are calculated and used throughout the codebase.

### Billing logic improvements

* Replaced usage of `GetTotalBilledDays` with `GetBilledDays` in `GetFreeEmployeesAction.cs`, now calculating billed days for a specific employee and their first project, rather than aggregating across all projects.
* Updated the `GetBillableEmployees` method to use the new `GetBilledDays` signature, which takes both the employee and the project, ensuring more precise billing per project.
* Added a new version of `GetBilledDays` in `EmployeesHelper.cs` that calculates billed days only for non-SSW (external) projects and ignores internal projects, improving accuracy. The previous methods for total billed days and simple billed days by hours are now commented out.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->