### PR TITLE
L⚠️ ◾ fix: replace retired LUIS so SophieBot can answer again

### DIFF
--- a/.github/workflows/SSW.SophieBot.dev.yml
+++ b/.github/workflows/SSW.SophieBot.dev.yml
@@ -174,6 +174,7 @@ jobs:
 
   migrate-luis-model:
     name: Migrate LUIS model
+    if: false # LUIS retired Oct 2025; NLU is now CLU (sswsophiebot-clu)
     needs: build
     runs-on: windows-latest
     environment: dev

--- a/.github/workflows/SSW.SophieBot.prod.yml
+++ b/.github/workflows/SSW.SophieBot.prod.yml
@@ -164,6 +164,7 @@ jobs:
 
   migrate-luis-model:
     name: Migrate LUIS model
+    if: false # LUIS retired Oct 2025; NLU is now CLU (sswsophiebot-clu)
     needs: build
     runs-on: windows-latest
     environment: prod

--- a/.github/workflows/scripts/PublishUtils.ps1
+++ b/.github/workflows/scripts/PublishUtils.ps1
@@ -61,8 +61,8 @@ function Merge-LUIS {
     
     $luisSettingsFile = Get-ChildItem -Path $generatedFolder -Filter "luis.settings.*.json" -file
     if (-not $luisSettingsFile) {
-        Write-Error "LUIS settings file not found in generated folder: $generatedFolder"
-        exit 1
+        Write-Host "No LUIS settings file found — skipping LUIS merge (CLU recognizer does not need it)."
+        return
     }
 
     $luisSettings = Get-Content $luisSettingsFile.FullName | ConvertFrom-Json

--- a/_scripts/import-clu.py
+++ b/_scripts/import-clu.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Convert SophieBot .lu files to a CLU project, then import, train, and deploy."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+
+API_VERSION = "2023-04-01"
+PROJECT = "sswsophiebot-clu"
+DEPLOYMENT = "production"
+MODEL = "production"
+LANGUAGE = "en"
+
+PREBUILT_MAP = {
+    "datetimeV2": "DateTime",
+    "datetime": "DateTime",
+    "personName": "Person.Name",
+    "geographyV2": "Geography.Location",
+    "email": "Email",
+    "number": "Quantity.Number",
+}
+
+LABEL_RE = re.compile(r"\{@([A-Za-z0-9_]+)(?:=((?:[^{}]|\{@[^}]*\})*))?\}")
+LIST_HEADER_RE = re.compile(r"^@\s*list\s+([A-Za-z0-9_]+)\s*=?\s*$")
+LIST_CANON_RE = re.compile(r"^-\s*([A-Za-z0-9_ -]+)\s*:\s*$")
+LIST_SYN_RE = re.compile(r"^-\s*(.+?)\s*$")
+INTENT_HEADER_RE = re.compile(r"^#\s+([A-Za-z0-9_]+)\s*$")
+
+
+def parse_labeled_utterance(raw: str):
+    """Return (plain_text, [{category, offset, length}]). Nested labels become multiple entities."""
+
+    def walk(text: str, base: int):
+        out = []
+        found = []
+        i = 0
+        while i < len(text):
+            if text.startswith("{@", i):
+                depth = 0
+                j = i
+                while j < len(text):
+                    if text.startswith("{@", j):
+                        depth += 1
+                        j += 2
+                        continue
+                    if text[j] == "}":
+                        depth -= 1
+                        j += 1
+                        if depth == 0:
+                            break
+                        continue
+                    j += 1
+                inner = text[i + 2 : j - 1]
+                if "=" in inner:
+                    name, value = inner.split("=", 1)
+                    value = value.strip()
+                else:
+                    name, value = inner, ""
+                name = name.strip()
+                child_text, child_entities = walk(value, base + len("".join(out)))
+                start = base + len("".join(out))
+                if child_text:
+                    found.append(
+                        {
+                            "category": name,
+                            "offset": start,
+                            "length": len(child_text),
+                        }
+                    )
+                found.extend(child_entities)
+                out.append(child_text)
+                i = j
+            else:
+                out.append(text[i])
+                i += 1
+        return "".join(out), found
+
+    plain, entities = walk(raw, 0)
+    seen = set()
+    unique = []
+    for ent in entities:
+        key = (ent["category"], ent["offset"], ent["length"])
+        if key in seen or ent["length"] <= 0:
+            continue
+        seen.add(key)
+        unique.append(ent)
+    return plain, unique
+
+
+def parse_lu(path: Path):
+    intents = set()
+    utterances = []
+    list_entities = defaultdict(lambda: defaultdict(list))
+    learned_entities = set()
+    current_intent = None
+    current_list = None
+    current_canon = None
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        intent_match = INTENT_HEADER_RE.match(stripped)
+        if intent_match:
+            current_intent = intent_match.group(1)
+            current_list = None
+            current_canon = None
+            intents.add(current_intent)
+            continue
+
+        list_match = LIST_HEADER_RE.match(stripped)
+        if list_match:
+            current_list = list_match.group(1)
+            current_canon = None
+            current_intent = None
+            continue
+
+        if stripped.startswith("@ "):
+            current_list = None
+            current_canon = None
+            ml = re.match(r"^@\s*ml\s+([A-Za-z0-9_]+)", stripped)
+            if ml:
+                learned_entities.add(ml.group(1))
+            continue
+
+        if current_list:
+            indent = len(line) - len(line.lstrip(" \t"))
+            canon_match = LIST_CANON_RE.match(stripped)
+            if canon_match and indent <= 1:
+                current_canon = canon_match.group(1).strip()
+                list_entities[current_list][current_canon]
+                continue
+            syn_match = LIST_SYN_RE.match(stripped)
+            if syn_match and current_canon:
+                syn = syn_match.group(1).strip().strip("'\"")
+                if syn:
+                    list_entities[current_list][current_canon].append(syn)
+            continue
+
+        if current_intent and stripped.startswith("-"):
+            utt = stripped[1:].strip()
+            if not utt or utt.startswith("^"):
+                continue
+            # Skip unexpanded entity placeholders like {@contact} with no value
+            if re.search(r"\{@[A-Za-z0-9_]+\}", utt):
+                continue
+            text, ents = parse_labeled_utterance(utt)
+            text = re.sub(r"\s+", " ", text).strip()
+            if not text:
+                continue
+            item = {
+                "text": text,
+                "language": LANGUAGE,
+                "intent": current_intent,
+            }
+            if ents:
+                item["entities"] = ents
+                for ent in ents:
+                    if ent["category"] not in PREBUILT_MAP:
+                        learned_entities.add(ent["category"])
+            utterances.append(item)
+
+    intents.add("None")
+    return intents, utterances, list_entities, learned_entities
+
+
+def build_project(intents, utterances, list_entities, learned_entities):
+    entities = []
+
+    for name, prebuilt in PREBUILT_MAP.items():
+        entities.append(
+            {
+                "category": name,
+                "compositionSetting": "combineComponents",
+                "prebuilts": [{"category": prebuilt}],
+            }
+        )
+
+    for name, canons in list_entities.items():
+        sublists = []
+        for key, synonyms in canons.items():
+            values = list(dict.fromkeys([key] + synonyms))
+            values = [v for v in values if v]
+            if not values:
+                continue
+            sublists.append(
+                {
+                    "listKey": key,
+                    "synonyms": [{"language": LANGUAGE, "values": values}],
+                }
+            )
+        if not sublists:
+            continue
+        entities.append(
+            {
+                "category": name,
+                "compositionSetting": "combineComponents",
+                "list": {"sublists": sublists},
+            }
+        )
+        learned_entities.discard(name)
+
+    reserved = set(PREBUILT_MAP) | set(list_entities)
+    for name in sorted(learned_entities):
+        if name in reserved:
+            continue
+        entities.append({"category": name, "compositionSetting": "combineComponents"})
+
+    # Drop entity labels whose category was not imported
+    known = {e["category"] for e in entities}
+    cleaned = []
+    seen_text = set()
+    for utt in utterances:
+        key = utt["text"].strip().lower()
+        if key in seen_text:
+            continue
+        seen_text.add(key)
+        if "entities" in utt:
+            utt = dict(utt)
+            text_len = len(utt["text"])
+            utt["entities"] = [
+                e
+                for e in utt["entities"]
+                if e["category"] in known
+                and e["offset"] >= 0
+                and e["length"] > 0
+                and e["offset"] + e["length"] <= text_len
+            ]
+            if not utt["entities"]:
+                utt.pop("entities")
+        cleaned.append(utt)
+
+    return {
+        "projectFileVersion": API_VERSION,
+        "stringIndexType": "Utf16CodeUnit",
+        "metadata": {
+            "projectKind": "Conversation",
+            "projectName": PROJECT,
+            "multilingual": False,
+            "description": "SophieBot replacement for retired LUIS",
+            "language": LANGUAGE,
+        },
+        "assets": {
+            "projectKind": "Conversation",
+            "intents": [{"category": name} for name in sorted(intents)],
+            "entities": entities,
+            "utterances": cleaned,
+        },
+    }
+
+
+def request(method, url, key, body=None, timeout=60):
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Ocp-Apim-Subscription-Key", key)
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+            payload = json.loads(raw.decode("utf-8")) if raw else {}
+            return resp.status, dict(resp.headers), payload
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        payload = {}
+        try:
+            payload = json.loads(raw.decode("utf-8")) if raw else {}
+        except json.JSONDecodeError:
+            payload = {"raw": raw.decode("utf-8", errors="replace")}
+        return exc.code, dict(exc.headers), payload
+
+
+def wait_job(url, key, timeout_s=900):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        status, _, payload = request("GET", url, key)
+        job = payload.get("status") or payload.get("jobStatus")
+        print(f"  job {job} ({status})")
+        if job in {"succeeded", "Succeeded"}:
+            return payload
+        if job in {"failed", "Failed", "cancelled", "Cancelled"}:
+            raise RuntimeError(f"CLU job failed: {json.dumps(payload)[:1000]}")
+        time.sleep(8)
+    raise TimeoutError(f"Timed out waiting for {url}")
+
+
+def main():
+    endpoint = os.environ["CQA_ENDPOINT"].rstrip("/")
+    key = os.environ["CQA_KEY"]
+    lu_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(
+        "bots/employee-finder/src/SSW.SophieBot/language-understanding/en-us/SSWSophieBot.en-us.lu"
+    )
+
+    intents, utterances, list_entities, learned = parse_lu(lu_path)
+    project = build_project(intents, utterances, list_entities, learned)
+    out = Path("/tmp/sswsophiebot-clu.json")
+    out.write_text(json.dumps(project, indent=2), encoding="utf-8")
+    print(
+        f"Wrote {out} intents={len(project['assets']['intents'])} "
+        f"entities={len(project['assets']['entities'])} "
+        f"utterances={len(project['assets']['utterances'])}"
+    )
+
+    import_url = (
+        f"{endpoint}/language/authoring/analyze-conversations/projects/{PROJECT}"
+        f"/:import?api-version={API_VERSION}"
+    )
+    status, headers, payload = request("POST", import_url, key, project)
+    print("import", status, payload)
+    if status not in (200, 202):
+        raise SystemExit(f"Import failed: {payload}")
+    job_url = headers.get("Operation-Location") or headers.get("operation-location")
+    if job_url:
+        wait_job(job_url, key)
+
+    train_url = (
+        f"{endpoint}/language/authoring/analyze-conversations/projects/{PROJECT}"
+        f"/:train?api-version={API_VERSION}"
+    )
+    status, headers, payload = request(
+        "POST", train_url, key, {"modelLabel": MODEL, "trainingMode": "standard"}
+    )
+    print("train", status, payload)
+    if status == 400 and "trainingMode" in json.dumps(payload):
+        status, headers, payload = request("POST", train_url, key, {"modelLabel": MODEL})
+        print("train-retry", status, payload)
+    if status not in (200, 202):
+        raise SystemExit(f"Train failed: {payload}")
+    job_url = headers.get("Operation-Location") or headers.get("operation-location")
+    if job_url:
+        wait_job(job_url, key, timeout_s=1800)
+
+    deploy_url = (
+        f"{endpoint}/language/authoring/analyze-conversations/projects/{PROJECT}"
+        f"/deployments/{DEPLOYMENT}?api-version={API_VERSION}"
+    )
+    status, headers, payload = request(
+        "PUT", deploy_url, key, {"trainedModelLabel": MODEL}
+    )
+    print("deploy", status, payload)
+    if status not in (200, 202):
+        raise SystemExit(f"Deploy failed: {payload}")
+    job_url = headers.get("Operation-Location") or headers.get("operation-location")
+    if job_url:
+        wait_job(job_url, key)
+
+    predict_url = f"{endpoint}/language/:analyze-conversations?api-version={API_VERSION}"
+    for text in (
+        "Who is in the Sydney office right now?",
+        "hi",
+        "Is Adam booked or free?",
+        "who is Adam Cogan?",
+    ):
+        status, _, payload = request(
+            "POST",
+            predict_url,
+            key,
+            {
+                "kind": "Conversation",
+                "analysisInput": {
+                    "conversationItem": {
+                        "id": "1",
+                        "participantId": "1",
+                        "text": text,
+                    }
+                },
+                "parameters": {
+                    "projectName": PROJECT,
+                    "deploymentName": DEPLOYMENT,
+                    "stringIndexType": "Utf16CodeUnit",
+                },
+            },
+        )
+        pred = (
+            payload.get("result", {})
+            .get("prediction", {})
+        )
+        print(
+            f"predict [{text!r}] intent={pred.get('topIntent')} "
+            f"entities={[e.get('category')+':'+e.get('text','') for e in pred.get('entities', [])]}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/bots/employee-finder/src/SSW.SophieBot.Components/Components/CommonComponent.cs
+++ b/bots/employee-finder/src/SSW.SophieBot.Components/Components/CommonComponent.cs
@@ -25,6 +25,7 @@ namespace SSW.SophieBot.Components.Components
 
             // Register Custom Question Answering recognizer
             services.AddDeclarativeType<CustomQuestionAnsweringRecognizer>(CustomQuestionAnsweringRecognizer.Kind);
+            services.AddDeclarativeType<CluRecognizer>(CluRecognizer.Kind);
         }
     }
 }

--- a/bots/employee-finder/src/SSW.SophieBot.Components/Recognizers/CluRecognizer.cs
+++ b/bots/employee-finder/src/SSW.SophieBot.Components/Recognizers/CluRecognizer.cs
@@ -1,0 +1,479 @@
+// Copyright (c) SSW. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using AdaptiveExpressions.Properties;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace SSW.SophieBot.Components.Recognizers
+{
+    /// <summary>
+    /// Composer recognizer that calls Conversational Language Understanding and
+    /// emits LUIS-shaped entities so existing SophieBot dialogs keep working.
+    /// </summary>
+    public class CluRecognizer : Recognizer
+    {
+        [JsonProperty("$kind")]
+        public const string Kind = "SSW.CluRecognizer";
+
+        private const string DefaultProjectName = "sswsophiebot-clu";
+        private const string DefaultDeploymentName = "production";
+        private const string ApiVersion = "2023-04-01";
+
+        private static readonly HttpClient HttpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(15)
+        };
+
+        private static readonly Regex NowRegex = new Regex(
+            @"\b(right now|currently|at the moment|now)\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex TodayRegex = new Regex(
+            @"\btoday\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Dictionary<string, string> SiteAliases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["sydney"] = "sydney",
+            ["melbourne"] = "melbourne",
+            ["brisbane"] = "brisbane",
+            ["newcastle"] = "newcastle",
+            ["hangzhou"] = "hangzhou",
+            ["china"] = "china",
+            ["remote"] = "remote",
+            ["remotely"] = "remote",
+        };
+
+        [JsonProperty("projectName")]
+        public StringExpression ProjectName { get; set; } = DefaultProjectName;
+
+        [JsonProperty("deploymentName")]
+        public StringExpression DeploymentName { get; set; } = DefaultDeploymentName;
+
+        [JsonProperty("endpoint")]
+        public StringExpression Endpoint { get; set; } = "=settings.qna.endpoint";
+
+        [JsonProperty("endpointKey")]
+        public StringExpression EndpointKey { get; set; } = "=settings.qna.endpointKey";
+
+        public override async Task<RecognizerResult> RecognizeAsync(
+            DialogContext dialogContext,
+            Activity activity,
+            CancellationToken cancellationToken,
+            Dictionary<string, string> telemetryProperties = null,
+            Dictionary<string, double> telemetryMetrics = null)
+        {
+            var result = new RecognizerResult
+            {
+                Text = activity.Text,
+                Intents = new Dictionary<string, IntentScore>(),
+                Entities = new JObject(),
+            };
+
+            if (string.IsNullOrWhiteSpace(activity.Text))
+            {
+                result.Intents["None"] = new IntentScore { Score = 1.0 };
+                return result;
+            }
+
+            try
+            {
+                var (endpoint, _) = Endpoint.TryGetValue(dialogContext.State);
+                var (endpointKey, _) = EndpointKey.TryGetValue(dialogContext.State);
+                var (projectName, _) = ProjectName.TryGetValue(dialogContext.State);
+                var (deploymentName, _) = DeploymentName.TryGetValue(dialogContext.State);
+
+                if (string.IsNullOrWhiteSpace(endpoint) || string.IsNullOrWhiteSpace(endpointKey))
+                {
+                    throw new InvalidOperationException("CLU endpoint or endpointKey is missing.");
+                }
+
+                projectName = string.IsNullOrWhiteSpace(projectName) ? DefaultProjectName : projectName;
+                deploymentName = string.IsNullOrWhiteSpace(deploymentName) ? DefaultDeploymentName : deploymentName;
+
+                var prediction = await PredictAsync(endpoint, endpointKey, projectName, deploymentName, activity.Text, cancellationToken)
+                    .ConfigureAwait(false);
+                MapPrediction(activity.Text, prediction, result);
+            }
+            catch (Exception ex)
+            {
+                result.Intents["None"] = new IntentScore { Score = 1.0 };
+                result.Properties["error"] = ex.Message;
+            }
+
+            TrackRecognizerResult(
+                dialogContext,
+                "CluRecognizerResult",
+                FillRecognizerResultTelemetryProperties(result, telemetryProperties, dialogContext),
+                telemetryMetrics);
+
+            return result;
+        }
+
+        private static async Task<JObject> PredictAsync(
+            string endpoint,
+            string endpointKey,
+            string projectName,
+            string deploymentName,
+            string text,
+            CancellationToken cancellationToken)
+        {
+            var url = $"{endpoint.TrimEnd('/')}/language/:analyze-conversations?api-version={ApiVersion}";
+            var body = new JObject
+            {
+                ["kind"] = "Conversation",
+                ["analysisInput"] = new JObject
+                {
+                    ["conversationItem"] = new JObject
+                    {
+                        ["id"] = "1",
+                        ["participantId"] = "1",
+                        ["text"] = text,
+                    }
+                },
+                ["parameters"] = new JObject
+                {
+                    ["projectName"] = projectName,
+                    ["deploymentName"] = deploymentName,
+                    ["stringIndexType"] = "Utf16CodeUnit",
+                }
+            };
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = new StringContent(body.ToString(Formatting.None), Encoding.UTF8, "application/json")
+            };
+            request.Headers.Add("Ocp-Apim-Subscription-Key", endpointKey);
+
+            using var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException($"CLU prediction failed ({(int)response.StatusCode}): {json}");
+            }
+
+            return JObject.Parse(json);
+        }
+
+        private static void MapPrediction(string text, JObject response, RecognizerResult result)
+        {
+            var prediction = response.SelectToken("result.prediction") as JObject ?? new JObject();
+            var intents = prediction["intents"] as JArray ?? new JArray();
+            var entities = prediction["entities"] as JArray ?? new JArray();
+
+            if (intents.Count == 0)
+            {
+                var top = prediction.Value<string>("topIntent") ?? "None";
+                result.Intents[top] = new IntentScore { Score = 1.0 };
+            }
+            else
+            {
+                foreach (var intent in intents)
+                {
+                    var name = intent.Value<string>("category") ?? "None";
+                    var score = intent.Value<double?>("confidenceScore") ?? 0;
+                    result.Intents[name] = new IntentScore { Score = score };
+                }
+            }
+
+            if (!result.Intents.ContainsKey("None"))
+            {
+                result.Intents["None"] = new IntentScore { Score = 0 };
+            }
+
+            var mapped = new JObject();
+            var instance = new JObject();
+            var luisEntities = new JObject();
+            JObject datetimeV2 = null;
+
+            foreach (var entity in entities.OfType<JObject>())
+            {
+                var category = entity.Value<string>("category");
+                var entityText = entity.Value<string>("text") ?? string.Empty;
+                var offset = entity.Value<int?>("offset") ?? 0;
+                var length = entity.Value<int?>("length") ?? entityText.Length;
+                if (string.IsNullOrEmpty(category))
+                {
+                    continue;
+                }
+
+                AddInstance(instance, category, entityText, offset, length, entity.Value<double?>("confidenceScore") ?? 0);
+
+                if (IsDateTimeCategory(category))
+                {
+                    datetimeV2 = ToLuisDatetimeV2(entity, entityText);
+                    AddValue(mapped, "datetimeV2", datetimeV2);
+                    AddValue(mapped, "datetime", new JObject
+                    {
+                        ["timex"] = new JArray(datetimeV2?["values"]?[0]?["timex"] ?? entityText),
+                        ["type"] = datetimeV2?.Value<string>("type") ?? "date",
+                    });
+                    continue;
+                }
+
+                if (category.Equals("site", StringComparison.OrdinalIgnoreCase)
+                    || category.Equals("remote", StringComparison.OrdinalIgnoreCase))
+                {
+                    var canonical = CanonicalSite(entityText);
+                    AddValue(mapped, "site", new JArray(canonical));
+                    AddValue(luisEntities, "site", new JArray(canonical));
+                    continue;
+                }
+
+                if (category.Equals("geographyV2", StringComparison.OrdinalIgnoreCase)
+                    || category.Equals("location", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddValue(mapped, "geographyV2", new JObject
+                    {
+                        ["type"] = "city",
+                        ["location"] = entityText,
+                    });
+                    continue;
+                }
+
+                if (category.Equals("personName", StringComparison.OrdinalIgnoreCase)
+                    || category.Equals("Person.Name", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddValue(mapped, "personName", entityText);
+                    AddContact(mapped, entityText);
+                    continue;
+                }
+
+                if (category.Equals("contact", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddContact(mapped, entityText);
+                    continue;
+                }
+
+                if (category.Equals("firstName", StringComparison.OrdinalIgnoreCase)
+                    || category.Equals("lastName", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddContactPart(mapped, category, entityText);
+                    continue;
+                }
+
+                AddValue(mapped, category, entityText);
+            }
+
+            ApplyLocationFallback(text, mapped);
+            datetimeV2 = ApplyDatetimeFallback(text, mapped, datetimeV2);
+
+            if (mapped["$instance"] == null && instance.HasValues)
+            {
+                mapped["$instance"] = instance;
+            }
+
+            result.Entities = mapped;
+
+            if (datetimeV2 != null)
+            {
+                luisEntities["datetimeV2"] = new JArray(datetimeV2);
+            }
+
+            result.Properties["luisResult"] = new JObject
+            {
+                ["prediction"] = new JObject
+                {
+                    ["topIntent"] = prediction.Value<string>("topIntent"),
+                    ["intents"] = prediction["intents"],
+                    ["entities"] = luisEntities,
+                }
+            };
+        }
+
+        private static bool IsDateTimeCategory(string category)
+        {
+            return category.Equals("datetimeV2", StringComparison.OrdinalIgnoreCase)
+                || category.Equals("datetime", StringComparison.OrdinalIgnoreCase)
+                || category.Equals("DateTime", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static JObject ToLuisDatetimeV2(JObject entity, string entityText)
+        {
+            var resolutions = entity["resolutions"] as JArray ?? new JArray();
+            var first = resolutions.FirstOrDefault() as JObject ?? new JObject();
+            var timex = first.Value<string>("timex") ?? entityText;
+            var subKind = (first.Value<string>("dateTimeSubKind") ?? first.Value<string>("resolutionKind") ?? "Date").ToLowerInvariant();
+            var type = subKind.Contains("range") ? "daterange"
+                : subKind.Contains("duration") ? "duration"
+                : subKind.Contains("time") && !subKind.Contains("date") ? "time"
+                : "date";
+
+            if (NowRegex.IsMatch(entityText) || string.Equals(timex, "PRESENT_REF", StringComparison.OrdinalIgnoreCase))
+            {
+                timex = "PRESENT_REF";
+                type = "date";
+            }
+
+            var resolution = new JObject();
+            if (first["begin"] != null || first["start"] != null)
+            {
+                resolution["start"] = first["begin"] ?? first["start"];
+                resolution["end"] = first["end"];
+                type = "daterange";
+            }
+            else
+            {
+                resolution["value"] = first.Value<string>("value") ?? entityText;
+            }
+
+            return new JObject
+            {
+                ["type"] = type,
+                ["values"] = new JArray(new JObject
+                {
+                    ["timex"] = timex,
+                    ["resolution"] = new JArray(resolution),
+                })
+            };
+        }
+
+        private static JObject ApplyDatetimeFallback(string text, JObject mapped, JObject existing)
+        {
+            if (mapped["datetimeV2"] != null)
+            {
+                return existing;
+            }
+
+            string timex = null;
+            if (NowRegex.IsMatch(text))
+            {
+                timex = "PRESENT_REF";
+            }
+            else if (TodayRegex.IsMatch(text))
+            {
+                timex = DateTime.UtcNow.ToString("yyyy-MM-dd");
+            }
+
+            if (timex == null)
+            {
+                return existing;
+            }
+
+            var datetimeV2 = new JObject
+            {
+                ["type"] = "date",
+                ["values"] = new JArray(new JObject
+                {
+                    ["timex"] = timex,
+                    ["resolution"] = new JArray(new JObject
+                    {
+                        ["value"] = DateTime.UtcNow.ToString("yyyy-MM-dd"),
+                    }),
+                })
+            };
+
+            AddValue(mapped, "datetimeV2", datetimeV2);
+            AddValue(mapped, "datetime", new JObject
+            {
+                ["timex"] = new JArray(timex),
+                ["type"] = "date",
+            });
+            return datetimeV2;
+        }
+
+        private static void ApplyLocationFallback(string text, JObject mapped)
+        {
+            if (mapped["site"] != null || mapped["geographyV2"] != null)
+            {
+                return;
+            }
+
+            foreach (var pair in SiteAliases)
+            {
+                if (Regex.IsMatch(text, $@"\b{Regex.Escape(pair.Key)}\b", RegexOptions.IgnoreCase))
+                {
+                    if (pair.Value == "remote")
+                    {
+                        AddValue(mapped, "remote", "remote");
+                    }
+                    else
+                    {
+                        AddValue(mapped, "site", new JArray(pair.Value));
+                    }
+                    return;
+                }
+            }
+        }
+
+        private static string CanonicalSite(string text)
+        {
+            return SiteAliases.TryGetValue(text.Trim(), out var canonical) ? canonical : text.Trim().ToLowerInvariant();
+        }
+
+        private static void AddContact(JObject mapped, string fullName)
+        {
+            var parts = fullName.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            var contact = mapped["contact"] as JArray ?? new JArray();
+            var item = contact.FirstOrDefault() as JObject ?? new JObject();
+            if (parts.Length > 0)
+            {
+                item["firstName"] = new JArray(parts[0]);
+            }
+            if (parts.Length > 1)
+            {
+                item["lastName"] = new JArray(string.Join(" ", parts.Skip(1)));
+            }
+            if (contact.Count == 0)
+            {
+                contact.Add(item);
+                mapped["contact"] = contact;
+            }
+        }
+
+        private static void AddContactPart(JObject mapped, string part, string value)
+        {
+            var contact = mapped["contact"] as JArray ?? new JArray();
+            var item = contact.FirstOrDefault() as JObject ?? new JObject();
+            item[part] = new JArray(value);
+            if (contact.Count == 0)
+            {
+                contact.Add(item);
+                mapped["contact"] = contact;
+            }
+        }
+
+        private static void AddValue(JObject mapped, string name, JToken value)
+        {
+            if (mapped[name] is JArray array)
+            {
+                array.Add(value);
+                return;
+            }
+
+            if (mapped[name] != null)
+            {
+                mapped[name] = new JArray(mapped[name], value);
+                return;
+            }
+
+            mapped[name] = new JArray(value);
+        }
+
+        private static void AddInstance(JObject instance, string category, string text, int offset, int length, double score)
+        {
+            var arr = instance[category] as JArray ?? new JArray();
+            arr.Add(new JObject
+            {
+                ["startIndex"] = offset,
+                ["endIndex"] = offset + length,
+                ["text"] = text,
+                ["score"] = score,
+                ["type"] = category,
+            });
+            instance[category] = arr;
+        }
+    }
+}

--- a/bots/employee-finder/src/SSW.SophieBot.Components/Recognizers/CluRecognizer.schema
+++ b/bots/employee-finder/src/SSW.SophieBot.Components/Recognizers/CluRecognizer.schema
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
+    "$role": "implements(Microsoft.IRecognizer)",
+    "title": "CLU recognizer",
+    "description": "Recognizer that calls Conversational Language Understanding and emits LUIS-shaped entities.",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "Optional unique id used with RecognizerSet."
+        },
+        "projectName": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "Project Name",
+            "description": "Conversational Language Understanding project name.",
+            "default": "sswsophiebot-clu"
+        },
+        "deploymentName": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "Deployment Name",
+            "description": "CLU deployment name.",
+            "default": "production"
+        },
+        "endpoint": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "Endpoint",
+            "description": "Language Service endpoint URL.",
+            "default": "=settings.qna.endpoint"
+        },
+        "endpointKey": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "Endpoint key",
+            "description": "Language Service API key.",
+            "default": "=settings.qna.endpointKey"
+        }
+    },
+    "required": [
+        "projectName",
+        "endpoint",
+        "endpointKey"
+    ]
+}

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/CheckAvailabilityDialog/recognizers/CheckAvailabilityDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/CheckAvailabilityDialog/recognizers/CheckAvailabilityDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_CheckAvailabilityDialog",
-  "applicationId": "=settings.luis.CheckAvailabilityDialog_en_us_lu.appId",
-  "version": "=settings.luis.CheckAvailabilityDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetAvailableExpertsByLocationDialog/recognizers/GetAvailableExpertsByLocationDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetAvailableExpertsByLocationDialog/recognizers/GetAvailableExpertsByLocationDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetAvailableExpertsByLocationDialog",
-  "applicationId": "=settings.luis.GetAvailableExpertsByLocationDialog_en_us_lu.appId",
-  "version": "=settings.luis.GetAvailableExpertsByLocationDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetBirthdate/recognizers/GetBirthdate.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetBirthdate/recognizers/GetBirthdate.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetBirthdate",
-  "applicationId": "=settings.luis.GetBirthdate_en_us_lu.appId",
-  "version": "=settings.luis.GetBirthdate_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetCalendarDialog/recognizers/GetCalendarDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetCalendarDialog/recognizers/GetCalendarDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetCalendarDialog",
-  "applicationId": "=settings.luis.GetCalendarDialog_en_us_lu.appId",
-  "version": "=settings.luis.GetCalendarDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetClient/recognizers/GetClient.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetClient/recognizers/GetClient.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetClient",
-  "applicationId": "=settings.luis.GetClient_en_us_lu.appId",
-  "version": "=settings.luis.GetClient_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetCooperators/recognizers/GetCooperators.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetCooperators/recognizers/GetCooperators.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetCooperators",
-  "applicationId": "=settings.luis.GetCooperators_en_us_lu.appId",
-  "version": "=settings.luis.GetCooperators_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetCurrentEmployeesOnLocationDialog/recognizers/GetCurrentEmployeesOnLocationDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetCurrentEmployeesOnLocationDialog/recognizers/GetCurrentEmployeesOnLocationDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetCurrentEmployeesOnLocationDialog",
-  "applicationId": "=settings.luis.GetCurrentEmployeesOnLocationDialog_en_us_lu.appId",
-  "version": "=settings.luis.GetCurrentEmployeesOnLocationDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetEmailAddressDialog/recognizers/GetEmailAddressDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetEmailAddressDialog/recognizers/GetEmailAddressDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetEmailAddressDialog",
-  "applicationId": "=settings.luis.GetEmailAddressDialog_en_us_lu.appId",
-  "version": "=settings.luis.GetEmailAddressDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetEmployeeProjects/recognizers/GetEmployeeProjects.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetEmployeeProjects/recognizers/GetEmployeeProjects.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetEmployeeProjects",
-  "applicationId": "=settings.luis.GetEmployeeProjects_en_us_lu.appId",
-  "version": "=settings.luis.GetEmployeeProjects_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetEmployeesByProjectDialog/recognizers/GetEmployeesByProjectDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetEmployeesByProjectDialog/recognizers/GetEmployeesByProjectDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetEmployeesByProjectDialog",
-  "applicationId": "=settings.luis.GetEmployeesByProjectDialog_en_us_lu.appId",
-  "version": "=settings.luis.GetEmployeesByProjectDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetExpertsByLocationDialog/recognizers/GetExpertsByLocationDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetExpertsByLocationDialog/recognizers/GetExpertsByLocationDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetExpertsByLocation",
-  "applicationId": "=settings.luis.GetExpertsByLocation_en_us_lu.appId",
-  "version": "=settings.luis.GetExpertsByLocation_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetFreeDayDialog/recognizers/GetFreeDayDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetFreeDayDialog/recognizers/GetFreeDayDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetFreeDayDialog",
-  "applicationId": "=settings.luis.GetFreeDayDialog_en_us_lu.appId",
-  "version": "=settings.luis.GetFreeDayDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetPeopleBasedOnLocationDialog/recognizers/GetPeopleBasedOnLocationDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetPeopleBasedOnLocationDialog/recognizers/GetPeopleBasedOnLocationDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetPeopleBasedOnLocationDialog",
-  "applicationId": "=settings.luis.GetPeopleBasedOnLocationDialog_en_us_lu.appId",
-  "version": "=settings.luis.GetPeopleBasedOnLocationDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetPeopleBySkills/recognizers/GetPeopleBySkills.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetPeopleBySkills/recognizers/GetPeopleBySkills.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetPeopleBySkills",
-  "applicationId": "=settings.luis.GetPeopleBySkills_en_us_lu.appId",
-  "version": "=settings.luis.GetPeopleBySkills_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetPeopleOnClientWorkDialog/recognizers/GetPeopleOnClientWorkDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetPeopleOnClientWorkDialog/recognizers/GetPeopleOnClientWorkDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetPeopleOnClientWorkDialog",
-  "applicationId": "=settings.luis.GetPeopleOnClientWorkDialog_en_us_lu.appId",
-  "version": "=settings.luis.GetPeopleOnClientWorkDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetPhoneNumberDialog/recognizers/GetPhoneNumberDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetPhoneNumberDialog/recognizers/GetPhoneNumberDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetPhoneNumberDialog",
-  "applicationId": "=settings.luis.GetPhoneNumberDialog_en_us_lu.appId",
-  "version": "=settings.luis.GetPhoneNumberDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetProfileDialog/recognizers/GetProfileDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetProfileDialog/recognizers/GetProfileDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetProfileDialog",
-  "applicationId": "=settings.luis.GetProfileDialog_en_us_lu.appId",
-  "version": "=settings.luis.GetProfileDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GetSkillsDialog/recognizers/GetSkillsDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GetSkillsDialog/recognizers/GetSkillsDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GetSkillsDialog",
-  "applicationId": "=settings.luis.GetSkillsDialog_en_us_lu.appId",
-  "version": "=settings.luis.GetSkillsDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/GreetingDialog/recognizers/GreetingDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/GreetingDialog/recognizers/GreetingDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_GreetingDialog",
-  "applicationId": "=settings.luis.GreetingDialog_en_us_lu.appId",
-  "version": "=settings.luis.GreetingDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/dialogs/UnknownIntentDialog/recognizers/UnknownIntentDialog.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/dialogs/UnknownIntentDialog/recognizers/UnknownIntentDialog.en-us.lu.dialog
@@ -1,8 +1,8 @@
 {
-  "$kind": "Microsoft.LuisRecognizer",
+  "$kind": "SSW.CluRecognizer",
   "id": "LUIS_UnknownIntentDialog",
-  "applicationId": "=settings.luis.UnknownIntentDialog_en_us_lu.appId",
-  "version": "=settings.luis.UnknownIntentDialog_en_us_lu.version",
-  "endpoint": "=settings.luis.endpoint",
-  "endpointKey": "=settings.luis.endpointKey"
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }

--- a/bots/employee-finder/src/SSW.SophieBot/recognizers/SSWSophieBot.en-us.lu.dialog
+++ b/bots/employee-finder/src/SSW.SophieBot/recognizers/SSWSophieBot.en-us.lu.dialog
@@ -1,11 +1,8 @@
 {
-	"$kind": "Microsoft.LuisRecognizer",
-	"id": "LUIS_SSWSophieBot",
-	"applicationId": "=settings.luis.SSWSophieBot_en_us_lu.appId",
-	"version": "=settings.luis.SSWSophieBot_en_us_lu.version",
-	"endpoint": "=settings.luis.endpoint",
-	"endpointKey": "=settings.luis.endpointKey",
-	"predictionOptions": {
-		"includeAPIResults": true
-	}
+  "$kind": "SSW.CluRecognizer",
+  "id": "LUIS_SSWSophieBot",
+  "projectName": "sswsophiebot-clu",
+  "deploymentName": "production",
+  "endpoint": "=settings.qna.endpoint",
+  "endpointKey": "=settings.qna.endpointKey"
 }


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

SophieBot is down. Azure LUIS now returns HTTP 410 (`The LUIS service has been deprecated and is no longer available`). Cross-trained QnA still answers `intent=DeferToRecognizer_LUIS_SSWSophieBot`, so every user query fails.

> 2. What was changed?

- Imported the existing `.lu` model into Conversational Language Understanding on the `sswsophiebot` Language resource (`sswsophiebot-clu` / `production`)
- Added `SSW.CluRecognizer` that calls CLU and emits LUIS-shaped entities (`site`, `contact`, `datetimeV2`, `luisResult`) so current dialogs keep working
- Pointed all Composer LUIS recognizers at CLU, reusing the existing CQA endpoint/key
- Stopped the LUIS publish merge / migrator from failing the pipeline

> 3. Did you do pair or mob programming?

No